### PR TITLE
Optimize calldata

### DIFF
--- a/contracts/l2/L2DAIWormholeBridge.sol
+++ b/contracts/l2/L2DAIWormholeBridge.sol
@@ -100,6 +100,14 @@ contract L2DAIWormholeBridge is OVM_CrossDomainEnabled {
   function initiateWormhole(
     bytes32 targetDomain,
     address receiver,
+    uint128 amount
+  ) external {
+    return _initiateWormhole(targetDomain, addressToBytes32(receiver), amount, 0);
+  }
+
+  function initiateWormhole(
+    bytes32 targetDomain,
+    address receiver,
     uint128 amount,
     address operator
   ) external {


### PR DESCRIPTION
Since we allow the receiver to mint the wormhole, in most cases we can drop the `operator` parameter entirely.  Calldata is much more expensive on L2s than on L1s so it makes sense. 